### PR TITLE
fix: CI pipeline fails when no test files exist

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,8 +10,7 @@ module.exports = {
     rootDir: './',
 
     roots: [
-        "<rootDir>/src",
-        "<rootDir>/tests"
+        "<rootDir>/src"
     ],
 
     testPathIgnorePatterns: [
@@ -38,14 +37,7 @@ module.exports = {
 
     coverageDirectory: "coverage",
 
-    coverageThreshold:{
-        global:{
-            branches: 50,
-            functions: 50,
-            lines: 50,
-            statements: 50,
-        },
-    },
+    coverageThreshold:{},
 
     moduleNameMapper:{
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "serve": "node dist/server.js",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
-    "test": "jest --detectOpenHandles --forceExit",
+    "test": "jest --detectOpenHandles --forceExit --passWithNoTests",
     "test:watch": "jest --watchAll --detectOpenHandles --forceExit",
     "test:coverage": "jest --coverage --detectOpenHandles --forceExit"
   }


### PR DESCRIPTION
- Remove tests/ from Jest roots (folder doesn't exist yet)
- Add --passWithNoTests flag so CI passes on empty test suite
- Remove coverage thresholds until test suite is established

Closes #24