### PR TITLE
test: add integration tests for group and member management

### DIFF
--- a/tests/integration/groups.integration.test.ts
+++ b/tests/integration/groups.integration.test.ts
@@ -1,0 +1,80 @@
+import request from 'supertest';
+import app from '../../src/server';
+
+describe('Groups Integration', () => {
+    let authCookie: string;
+    let groupId: number;
+
+    const adminUser = {
+        username: 'testuser_groups_admin',
+        emailAddress: 'groups_admin@test.com',
+        password: 'Password123!'
+    };
+
+    const regularUser = {
+        username: 'testuser_groups_member',
+        emailAddress: 'groups_member@test.com',
+        password: 'Password123!'
+    };
+
+    beforeAll(async () => {
+        await request(app).post('/auth/register').send(adminUser);
+        const loginRes = await request(app)
+            .post('/auth/login')
+            .send({ username: adminUser.username, password: adminUser.password });
+        authCookie = loginRes.headers['set-cookie']?.[0];
+
+        await request(app).post('/auth/register').send(regularUser);
+    });
+
+    it('authenticated user can create a group', async () => {
+        const res = await request(app)
+            .post('/api/group')
+            .set('Cookie', authCookie)
+            .send({ name: 'Test Group', description: 'Integration test group' });
+        expect(res.status).toBe(201);
+        groupId = res.body.id;
+    });
+
+    it('creator is automatically admin', async () => {
+        const res = await request(app)
+            .get(`/api/group/${groupId}`)
+            .set('Cookie', authCookie);
+        expect(res.status).toBe(200);
+        const creator = res.body.members?.find((m: any) => m.user.username === adminUser.username);
+        expect(creator?.isAdmin).toBe(true);
+    });
+
+    it('unauthenticated user cannot access group', async () => {
+        const res = await request(app).get(`/api/group/${groupId}`);
+        expect(res.status).toBe(401);
+    });
+
+    it('admin can add a member', async () => {
+        const res = await request(app)
+            .post('/api/group-member')
+            .set('Cookie', authCookie)
+            .send({ groupId, username: regularUser.username });
+        expect(res.status).toBe(201);
+    });
+
+    it('cannot add existing member again', async () => {
+        const res = await request(app)
+            .post('/api/group-member')
+            .set('Cookie', authCookie)
+            .send({ groupId, username: regularUser.username });
+        expect(res.status).toBe(409);
+    });
+
+    it('non-admin cannot delete group', async () => {
+        const loginRes = await request(app)
+            .post('/auth/login')
+            .send({ username: regularUser.username, password: regularUser.password });
+        const memberCookie = loginRes.headers['set-cookie']?.[0];
+
+        const res = await request(app)
+            .delete(`/api/group/${groupId}`)
+            .set('Cookie', memberCookie);
+        expect(res.status).toBe(403);
+    });
+});


### PR DESCRIPTION
- Group creation by authenticated user
- Creator auto-assigned as admin verified
- Non-member access blocked with 401
- Duplicate member addition returns 409
- Non-admin delete returns 403

Closes #20