### PR TITLE
fix: correct modal script paths and clean up layout modal handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "5433:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U flowshare"]
       interval: 10s

--- a/view/layout.ejs
+++ b/view/layout.ejs
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="/layout.css">
     <link rel="stylesheet" href="/pages/pages.css">
     <link rel="stylesheet" href="/components/components.css">
-    <link rel="stylesheet" href="/utils/modal.css">
+    <link rel="stylesheet" href="/pages/utils/modal.css">
     
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
 </head>
@@ -87,7 +87,7 @@
     </div>
     <% } %>
 
-    <script src="/utils/modal.js"></script>
+    <script src="/pages/utils/modal.js"></script>
     <script src="/layout.js"></script>
     
 </body>

--- a/view/layout.js
+++ b/view/layout.js
@@ -1,12 +1,10 @@
 document.addEventListener("DOMContentLoaded", () => {
   const logoutBtn = document.getElementById("logout-btn");
-  const logoutModal = document.getElementById("logout-modal");
   const confirmLogoutBtn = document.getElementById("confirm-logout-btn");
 
-  if (logoutBtn && logoutModal) {
+  if (logoutBtn) {
     logoutBtn.addEventListener("click", () => {
-      logoutModal.classList.remove("hidden");
-      logoutModal.classList.add("active");
+      openModal("logout-modal");
     });
   }
 
@@ -18,9 +16,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const response = await fetch("/auth/logout", {
           method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
+          headers: { "Content-Type": "application/json" },
         });
 
         if (response.ok) {
@@ -39,53 +35,8 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
-  const closeButtons = document.querySelectorAll("[data-close-modal]");
-  closeButtons.forEach((button) => {
-    button.addEventListener("click", () => {
-      const modalId = button.getAttribute("data-close-modal");
-      const modal = document.getElementById(modalId);
-      if (modal) {
-        modal.classList.add("hidden");
-        modal.classList.remove("active");
-      }
-    });
-  });
-
-  const modalCloseButtons = document.querySelectorAll(".modal-close");
-  modalCloseButtons.forEach((button) => {
-    button.addEventListener("click", () => {
-      const modal = button.closest(".modal");
-      if (modal) {
-        modal.classList.add("hidden");
-        modal.classList.remove("active");
-      }
-    });
-  });
-
-  const modalOverlays = document.querySelectorAll(".modal-overlay");
-  modalOverlays.forEach((overlay) => {
-    overlay.addEventListener("click", () => {
-      const modal = overlay.closest(".modal");
-      if (modal) {
-        modal.classList.add("hidden");
-        modal.classList.remove("active");
-      }
-    });
-  });
-
-  document.addEventListener("keydown", (e) => {
-    if (e.key === "Escape") {
-      const activeModal = document.querySelector(".modal.active");
-      if (activeModal) {
-        activeModal.classList.add("hidden");
-        activeModal.classList.remove("active");
-      }
-    }
-  });
-
   const currentPath = window.location.pathname;
   const navLinks = document.querySelectorAll(".nav-link");
-
   navLinks.forEach((link) => {
     if (link.getAttribute("href") === currentPath) {
       link.classList.add("active");


### PR DESCRIPTION
- layout.ejs: fix /utils/modal.{css,js} paths to /pages/utils/ — was 404ing so openModal was never defined, breaking all component modal calls
- layout.js: use openModal('logout-modal') instead of manual class toggle; remove duplicate close/overlay/escape handlers now owned by modal.js
- docker-compose.yml: fix postgres port mapping to 5433 Closes #38