### PR TITLE
feat: add GitHub Actions CD pipeline for Oracle deployment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,22 @@
+name: CD
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Deploy to Oracle
+
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            cd ~/flow-share
+            git pull origin main
+            docker compose up --build -d


### PR DESCRIPTION
- Triggers on push to main
- Deploys via SSH to Oracle Free Tier
- Runs docker compose up --build -d on server

Closes #3