### PR TITLE
fix: use docker-compose command compatible with server installation

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,4 +19,4 @@ jobs:
           script: |
             cd ~/flow-share
             git pull origin main
-            docker compose up --build -d
+            docker-compose up --build -d


### PR DESCRIPTION
## Description
Fix CD pipeline deployment command and complete Oracle server configuration.
The `docker compose` (plugin syntax) was replaced with `docker-compose` (standalone)
to match the version installed on the production server. Server-side setup was
completed manually: Docker installed, repository cloned, `.env` configured,
SSH key pair generated and added to GitHub Secrets.

## Related Issue
Closes #4

## Type of change
- [ ] New feature
- [x] Bug fix
- [ ] Refactor / cleanup
- [x] Documentation / config

## Testing
- [x] `npm test` passes locally
- [x] Tested manually in browser
- [ ] Added/updated tests for changes

## Checklist
- [x] No direct push to main
- [x] PR linked to an Issue
- [x] At least one reviewer assigned
