### PR TITLE
fix: exclude passwordHash from group members API response

### DIFF
--- a/src/services/group-member-service.ts
+++ b/src/services/group-member-service.ts
@@ -14,7 +14,16 @@ export const getGroupMembers = async (
             groupId: groupId,
         },
         include: {
-            user: true,
+            user: {
+                select: {
+                    id: true,
+                    username: true,
+                    emailAddress: true,
+                    isVerified: true,
+                    createdAt: true,
+                    updatedAt: true,
+                }
+            }
         },
     });
 


### PR DESCRIPTION
The getGroupMembers service was using 'include: { user: true }' which returned the full User object including passwordHash. Replaced with an explicit select to expose only safe public fields.

Closes 52

## Description

## Related Issue
Closes #52 

## Type of change
- [ ] New feature
- [x] Bug fix
- [ ] Refactor / cleanup
- [ ] Documentation / config

## Testing
- [x] `npm test` passes locally
- [x] Tested manually in browser
- [x] Added/updated tests for changes

## Checklist
- [x] No direct push to main
- [x] PR linked to an Issue
- [x] At least one reviewer assigned
